### PR TITLE
Write commands only if joint has any command interfaces defined

### DIFF
--- a/src/feetech_ros2_driver.cpp
+++ b/src/feetech_ros2_driver.cpp
@@ -144,7 +144,7 @@ hardware_interface::return_type FeetechHardwareInterface::write(const rclcpp::Ti
     if (!info_.joints[i].command_interfaces.empty()) {
       commanded_joint_ids.push_back(joint_ids_[i]);
       commanded_positions.push_back(feetech_driver::from_radians(hw_positions_[i]) + joint_offsets_[i]);
-      commanded_speeds.push_back(2400);  // Default speed
+      commanded_speeds.push_back(2400);       // Default speed
       commanded_accelerations.push_back(50);  // Default acceleration
     }
   }

--- a/src/feetech_ros2_driver.cpp
+++ b/src/feetech_ros2_driver.cpp
@@ -103,7 +103,9 @@ std::vector<hardware_interface::CommandInterface> FeetechHardwareInterface::expo
   std::vector<hardware_interface::CommandInterface> command_interfaces;
   hw_positions_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
   for (uint i = 0; i < info_.joints.size(); i++) {
-    command_interfaces.emplace_back(info_.joints[i].name, hardware_interface::HW_IF_POSITION, &hw_positions_[i]);
+    if (!info_.joints[i].command_interfaces.empty()) {
+      command_interfaces.emplace_back(info_.joints[i].name, hardware_interface::HW_IF_POSITION, &hw_positions_[i]);
+    }
   }
 
   return command_interfaces;
@@ -131,18 +133,32 @@ hardware_interface::return_type FeetechHardwareInterface::read(const rclcpp::Tim
 
 hardware_interface::return_type FeetechHardwareInterface::write(const rclcpp::Time& /* time */,
                                                                 const rclcpp::Duration& /* period */) {
-  const auto positions = ranges::views::zip(hw_positions_, joint_offsets_) |
-                         ranges::views::transform([&](const auto tuple) {
-                           auto [position, offset] = tuple;
-                           return feetech_driver::from_radians(position) + offset;
-                         }) |
-                         ranges::to_vector;
-  const auto write_result = communication_protocol_->sync_write_position(
-      joint_ids_, positions, std::vector(joint_ids_.size(), 2400), std::vector(joint_ids_.size(), 50));
-  if (!write_result) {
-    spdlog::error("FeetechHardwareInterface::write -> {}", write_result.error());
-    return hardware_interface::return_type::ERROR;
+  // Create vectors only for joints that have command interfaces
+  std::vector<uint8_t> commanded_joint_ids;
+  std::vector<int> commanded_positions;
+  std::vector<int> commanded_speeds;
+  std::vector<int> commanded_accelerations;
+
+  for (uint i = 0; i < info_.joints.size(); i++) {
+    // Only include joints with command interfaces
+    if (!info_.joints[i].command_interfaces.empty()) {
+      commanded_joint_ids.push_back(joint_ids_[i]);
+      commanded_positions.push_back(feetech_driver::from_radians(hw_positions_[i]) + joint_offsets_[i]);
+      commanded_speeds.push_back(2400);  // Default speed
+      commanded_accelerations.push_back(50);  // Default acceleration
+    }
   }
+
+  // Only send commands if there are joints to command
+  if (!commanded_joint_ids.empty()) {
+    const auto write_result = communication_protocol_->sync_write_position(
+        commanded_joint_ids, commanded_positions, commanded_speeds, commanded_accelerations);
+    if (!write_result) {
+      spdlog::error("FeetechHardwareInterface::write -> {}", write_result.error());
+      return hardware_interface::return_type::ERROR;
+    }
+  }
+
   return hardware_interface::return_type::OK;
 }
 


### PR DESCRIPTION
Thanks for creating this driver! it works great! 

I've been trying to use this driver to also broadcast joint states of the "Follower" so100 arm.  I start a `controller_manager` node and load only the `joint_state_broadcaster/JointStateBroadcaster`  while passing in a ros2_control.xacro with all joints only having `state_interfaces` defined. 

When doing so, I observe that servo commands are still written to the motors to hold them at their current positions. This prevents the the follower arm from being moved freely if the gearbox is still connected and in cases where the final transmission gear was removed, it still leads to the motors spinning (freely) as the arm is moved. 


This PR aims to fix this problem by updating the `write` method to only send commands to joints/motors that have command_interfaces configured in the ros2_control.xacro. 