### PR TITLE
Disable holding torque for joints without command interfaces

### DIFF
--- a/src/feetech_ros2_driver.cpp
+++ b/src/feetech_ros2_driver.cpp
@@ -61,6 +61,10 @@ CallbackReturn FeetechHardwareInterface::on_init(const hardware_interface::Hardw
         }
       }
     }
+    // Disable holding torque for joints that do not have command interfaces.
+    if (info_.joints[i].command_interfaces.empty()) {
+      communication_protocol_->set_torque(joint_ids_[i], false);
+    }
   }
 
   const auto joint_model_series = joint_ids_ | ranges::views::transform([&](const auto id) {


### PR DESCRIPTION
Follow up to #9 where I spoke about needed to disable holding torque but forgot to commit the actual changes. 