### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,13 @@ add_library(${PROJECT_NAME} src/feetech_ros2_driver.cpp)
 target_include_directories(
   ${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                          $<INSTALL_INTERFACE:include>)
-ament_target_dependencies(${PROJECT_NAME} rclcpp rclcpp_lifecycle
-                          lifecycle_msgs hardware_interface pluginlib)
+target_link_libraries(${PROJECT_NAME} PUBLIC
+    rclcpp
+    rclcpp_lifecycle
+    lifecycle_msgs
+    hardware_interface
+    pluginlib
+)
 target_link_libraries(${PROJECT_NAME} communication_protocol
                       serial_port)
 


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
