### PR TITLE
fix error for colcon build

### DIFF
--- a/feetech_driver/examples/demo.cpp
+++ b/feetech_driver/examples/demo.cpp
@@ -168,7 +168,7 @@ int main(int argc, char** argv) {
     for (const auto& [key, _] : kExamples) {
       keys.push_back(key);
     }
-    spdlog::error("Invalid example name: {} - Available examples: {}", argv[1], keys);
+    spdlog::error("Invalid example name: {} - Available examples: {}", argv[1], keys | ranges::views::join(", "));
     return EXIT_FAILURE;
   }
 

--- a/feetech_driver/examples/demo.cpp
+++ b/feetech_driver/examples/demo.cpp
@@ -1,6 +1,7 @@
 #include <spdlog/spdlog.h>
 
 #include <feetech_driver/communication_protocol.hpp>
+#include <fmt/ranges.h>
 #include <iostream>
 #include <range/v3/all.hpp>
 #include <thread>

--- a/feetech_driver/examples/demo.cpp
+++ b/feetech_driver/examples/demo.cpp
@@ -169,7 +169,7 @@ int main(int argc, char** argv) {
     for (const auto& [key, _] : kExamples) {
       keys.push_back(key);
     }
-    spdlog::error("Invalid example name: {} - Available examples: {}", argv[1], keys | ranges::views::join(", "));
+    spdlog::error("Invalid example name: {} - Available examples: {}", argv[1], fmt::join(keys, ", "));
     return EXIT_FAILURE;
   }
 

--- a/feetech_driver/examples/demo.cpp
+++ b/feetech_driver/examples/demo.cpp
@@ -1,7 +1,7 @@
+#include <fmt/ranges.h>
 #include <spdlog/spdlog.h>
 
 #include <feetech_driver/communication_protocol.hpp>
-#include <fmt/ranges.h>
 #include <iostream>
 #include <range/v3/all.hpp>
 #include <thread>


### PR DESCRIPTION
There is an error when I colcon build on my machine:
<pre>
/usr/include/fmt/core.h:3146:17: note: candidate: ‘OutputIt fmt::v8::format_to(OutputIt, format_string<T ...>, T&& ...) [with OutputIt = appender; T = {unsigned int&}; typename std::enable_if<detail::is_output_iterator<OutputIt, char>::value, int>::type <anonymous> = 0; format_string<T ...> = basic_format_string<char, unsigned int&>]’
 3146 | FMT_INLINE auto format_to(OutputIt out, format_string<T...> fmt, T&&... args)
      |                 ^~~~~~~~~
In file included from /usr/include/c++/13/bits/chrono_io.h:39,
                 from /usr/include/c++/13/chrono:3330,
                 from /usr/include/spdlog/common.h:10:
/usr/include/c++/13/format:3774:5: note: candidate: ‘_Out std::format_to(_Out, format_string<_Args ...>, _Args&& ...) [with _Out = fmt::v8::appender; _Args = {unsigned int&}; format_string<_Args ...> = basic_format_string<char, unsigned int&>]’
 3774 |     format_to(_Out __out, format_string<_Args...> __fmt, _Args&&... __args)
      |     ^~~~~~~~~
/usr/include/fmt/ranges.h:494:26: error: call of overloaded ‘format_to(fmt::v8::appender&, const char [9], uint32_t&)’ is ambiguous
  494 |           out = format_to(out, "\\u{:04x}", escape.cp);
      |                 ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/core.h:3146:17: note: candidate: ‘OutputIt fmt::v8::format_to(OutputIt, format_string<T ...>, T&& ...) [with OutputIt = appender; T = {unsigned int&}; typename std::enable_if<detail::is_output_iterator<OutputIt, char>::value, int>::type <anonymous> = 0; format_string<T ...> = basic_format_string<char, unsigned int&>]’
 3146 | FMT_INLINE auto format_to(OutputIt out, format_string<T...> fmt, T&&... args)
      |                 ^~~~~~~~~
/usr/include/c++/13/format:3774:5: note: candidate: ‘_Out std::format_to(_Out, format_string<_Args ...>, _Args&& ...) [with _Out = fmt::v8::appender; _Args = {unsigned int&}; format_string<_Args ...> = basic_format_string<char, unsigned int&>]’
 3774 |     format_to(_Out __out, format_string<_Args...> __fmt, _Args&&... __args)
      |     ^~~~~~~~~
/usr/include/fmt/ranges.h:498:26: error: call of overloaded ‘format_to(fmt::v8::appender&, const char [9], uint32_t&)’ is ambiguous
  498 |           out = format_to(out, "\\U{:08x}", escape.cp);
      |                 ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/core.h:3146:17: note: candidate: ‘OutputIt fmt::v8::format_to(OutputIt, format_string<T ...>, T&& ...) [with OutputIt = appender; T = {unsigned int&}; typename std::enable_if<detail::is_output_iterator<OutputIt, char>::value, int>::type <anonymous> = 0; format_string<T ...> = basic_format_string<char, unsigned int&>]’
 3146 | FMT_INLINE auto format_to(OutputIt out, format_string<T...> fmt, T&&... args)
      |                 ^~~~~~~~~
/usr/include/c++/13/format:3774:5: note: candidate: ‘_Out std::format_to(_Out, format_string<_Args ...>, _Args&& ...) [with _Out = fmt::v8::appender; _Args = {unsigned int&}; format_string<_Args ...> = basic_format_string<char, unsigned int&>]’
 3774 |     format_to(_Out __out, format_string<_Args...> __fmt, _Args&&... __args)
      |     ^~~~~~~~~
/usr/include/fmt/ranges.h:504:24: error: call of overloaded ‘format_to(fmt::v8::appender&, const char [9], std::make_unsigned<char>::type)’ is ambiguous
  504 |         out = format_to(
      |               ~~~~~~~~~^
  505 |             out, "\\x{:02x}",
      |             ~~~~~~~~~~~~~~~~~
  506 |             static_cast<typename std::make_unsigned<Char>::type>(escape_char));
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/core.h:3146:17: note: candidate: ‘OutputIt fmt::v8::format_to(OutputIt, format_string<T ...>, T&& ...) [with OutputIt = appender; T = {unsigned char}; typename std::enable_if<detail::is_output_iterator<OutputIt, char>::value, int>::type <anonymous> = 0; format_string<T ...> = basic_format_string<char, unsigned char>]’
 3146 | FMT_INLINE auto format_to(OutputIt out, format_string<T...> fmt, T&&... args)
      |                 ^~~~~~~~~
/usr/include/c++/13/format:3774:5: note: candidate: ‘_Out std::format_to(_Out, format_string<_Args ...>, _Args&& ...) [with _Out = fmt::v8::appender; _Args = {unsigned char}; format_string<_Args ...> = basic_format_string<char, unsigned char>]’
 3774 |     format_to(_Out __out, format_string<_Args...> __fmt, _Args&&... __args)
      |     ^~~~~~~~~
</pre>

