### PR TITLE
Deprecation notices should be seen. Do not convert warnings into errors.

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -20,6 +20,7 @@ jobs:
     env:
       CCACHE_DIR: /github/home/.ccache
       ROS_REPO: main
+      TARGET_CMAKE_ARGS: -DWARNINGS_AS_ERRORS=ON
 
     runs-on: ubuntu-latest
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,12 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+option(WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
+
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  if(WARNINGS_AS_ERRORS)
+    add_compile_options(-Werror)
+  endif()
   add_compile_options(
     -Wall
     -Wextra


### PR DESCRIPTION
This package is currently blocking ros2_control releases to Jazzy.
https://github.com/ros/rosdistro/pull/47292