### PR TITLE
Fix deprecated hardware_interface API

### DIFF
--- a/include/feetech_ros2_driver/feetech_ros2_driver.hpp
+++ b/include/feetech_ros2_driver/feetech_ros2_driver.hpp
@@ -16,7 +16,7 @@ using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface
 
 class FeetechHardwareInterface : public hardware_interface::SystemInterface {
  public:
-  CallbackReturn on_init(const hardware_interface::HardwareInfo& info) override;
+  CallbackReturn on_init(const hardware_interface::HardwareComponentInterfaceParams& params) override;
 
   std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
 

--- a/src/feetech_ros2_driver.cpp
+++ b/src/feetech_ros2_driver.cpp
@@ -14,8 +14,8 @@
 #include <vector>
 
 namespace feetech_ros2_driver {
-CallbackReturn FeetechHardwareInterface::on_init(const hardware_interface::HardwareInfo& info) {
-  if (hardware_interface::SystemInterface::on_init(info) != CallbackReturn::SUCCESS) {
+CallbackReturn FeetechHardwareInterface::on_init(const hardware_interface::HardwareComponentInterfaceParams& params) {
+  if (hardware_interface::SystemInterface::on_init(params) != CallbackReturn::SUCCESS) {
     return CallbackReturn::ERROR;
   }
 


### PR DESCRIPTION
See https://github.com/ros-controls/ros2_control/pull/2323
needed for https://github.com/ros-controls/ros2_control/pull/2589

Please release it to kilted and rolling, thanks :)
Note: This API is not available on humble.