### PR TITLE
Fix unused result warning

### DIFF
--- a/feetech_driver/src/serial_port.cpp
+++ b/feetech_driver/src/serial_port.cpp
@@ -78,7 +78,7 @@ Expected<LibSerial::BaudRate> to_baudrate(const std::size_t baud) noexcept {
 
 SerialPort::SerialPort(const std::string& dev) : dev_(dev) { spdlog::info("Connecting to port: {}", dev); }
 
-SerialPort::~SerialPort() { 
+SerialPort::~SerialPort() {
   (void)close();  // explicitly discards result
 }
 


### PR DESCRIPTION
Fixes an unused result warning treated as error, which kicked this package off the buildfarm.

This happened because `tl_expected` vendor recently [bumped its version to 1.2.0](https://github.com/PickNikRobotics/cpp_polyfills/commit/d570d57cb394ef68b13d57f93c596371890ae58e), which seems to adds a `[[nodiscard]]` to `tl::expected` (see https://github.com/TartanLlama/expected/pull/165).

```
/tmp/binarydeb/ros-humble-feetech-ros2-driver-0.1.0/src/serial_port.cpp: In destructor ‘feetech_hardware_interface::SerialPort::~SerialPort()’:
/tmp/binarydeb/ros-humble-feetech-ros2-driver-0.1.0/src/serial_port.cpp:82:36: error: ignoring returned value of type ‘feetech_hardware_interface::Result’ {aka ‘tl::expected<void, std::__cxx11::basic_string<char> >’}, declared with attribute ‘nodiscard’ [-Werror=unused-result]
   82 | SerialPort::~SerialPort() { close(); }
      |                                    ^
In file included from /tmp/binarydeb/ros-humble-feetech-ros2-driver-0.1.0/src/serial_port.cpp:3:
/tmp/binarydeb/ros-humble-feetech-ros2-driver-0.1.0/include/feetech_hardware_interface/serial_port.hpp:19:10: note: in call to ‘feetech_hardware_interface::Result feetech_hardware_interface::SerialPort::close()’, declared here
   19 |   Result close();
      |          ^~~~~
In file included from /tmp/binarydeb/ros-humble-feetech-ros2-driver-0.1.0/include/feetech_hardware_interface/serial_port.hpp:7,
                 from /tmp/binarydeb/ros-humble-feetech-ros2-driver-0.1.0/src/serial_port.cpp:3:
/tmp/binarydeb/ros-humble-feetech-ros2-driver-0.1.0/include/feetech_hardware_interface/common.hpp:18:7: note: ‘feetech_hardware_interface::Result’ {aka ‘tl::expected<void, std::__cxx11::basic_string<char> >’} declared here
   18 | using Result = Expected<void>;
      |       ^~~~~~
cc1plus: all warnings being treated as errors
```

See [this link](https://build.ros2.org/view/Hbin_uJ64/job/Hbin_uJ64__feetech_ros2_driver__ubuntu_jammy_amd64__binary/36/console#:~:text=%E2%80%98tl%3A%3Aexpected%3Cvoid%2C%20std%3A%3A__cxx11%3A%3Abasic_string%3Cchar%3E%20%3E%E2%80%99%7D%2C%20declared%20with%20attribute%20%E2%80%98nodiscard%E2%80%99%20%5B%2DWerror%3Dunused%2Dresult%5D%0A%20%20%2082%20%7C%20SerialPort%3A%3A~SerialPort()%20%7B%20close()%3B%20%7D)