### PR TITLE
Fix nodiscard errors by explicitly discarding.

### DIFF
--- a/feetech_driver/examples/demo.cpp
+++ b/feetech_driver/examples/demo.cpp
@@ -21,7 +21,7 @@ static constexpr auto kSleepTime = 100ms;
 
 void print_models(CommunicationProtocol& communication_protocol) {
   for (std::size_t id = 0; id <= kMaxServoId; id++) {
-    communication_protocol.read_model_number(id)
+    (void)communication_protocol.read_model_number(id)
         .and_then(get_model_name)
         .and_then([=](const auto model_name) {
           spdlog::info("Servo ID: {} - Model name: {}", id, model_name);
@@ -33,7 +33,7 @@ void print_models(CommunicationProtocol& communication_protocol) {
 
 void ping(CommunicationProtocol& communication_protocol) {
   const auto id = std::stoi(get_input("Enter servo ID: "));
-  communication_protocol.ping(id)
+  (void)communication_protocol.ping(id)
       .and_then([] {
         spdlog::info("Ping success");
         return Result{};
@@ -47,7 +47,7 @@ void sync_read_position(CommunicationProtocol& communication_protocol) {
   std::vector<std::array<uint8_t, 2>> positions(num_servos, {0, 0});
 
   while (true) {
-    communication_protocol.sync_read(ids, SMS_STS_PRESENT_POSITION_L, &positions)
+    (void)communication_protocol.sync_read(ids, SMS_STS_PRESENT_POSITION_L, &positions)
         .or_else([&](const std::string& error) {
           throw std::runtime_error(fmt::format("Failed to read position [ids={}]", ids, error));
         });
@@ -80,7 +80,7 @@ void sync_write_position(CommunicationProtocol& communication_protocol) {
     std::vector<int> positions(num_servos, from_angle(desired_joint_position));
 
     spdlog::info("Setting positions to {}", positions);
-    communication_protocol.sync_write_position(ids, positions, speeds, accelerations)
+    (void)communication_protocol.sync_write_position(ids, positions, speeds, accelerations)
         .or_else([=](const std::string& error) {
           throw std::runtime_error(fmt::format("Failed to set position [ids={}]", ids, error));
         });
@@ -95,12 +95,12 @@ void reg_write_position(CommunicationProtocol& communication_protocol) {
 
     spdlog::info("Setting position to {}°: {}", desired_joint_position, data);
     for (uint8_t servo_id = 1; servo_id <= num_servos; servo_id++) {
-      communication_protocol.reg_write_position(servo_id, data, 0, 0).or_else([=](const std::string& error) {
+      (void)communication_protocol.reg_write_position(servo_id, data, 0, 0).or_else([=](const std::string& error) {
         throw std::runtime_error(fmt::format("Failed to set position [id={}][{}]", servo_id, error));
       });
     }
     get_input("Press enter to continue");
-    communication_protocol.reg_write_action().or_else([](const std::string& error) {
+    (void)communication_protocol.reg_write_action().or_else([](const std::string& error) {
       throw std::runtime_error(fmt::format("Failed to set position action [{}]", error));
     });
   }
@@ -108,7 +108,7 @@ void reg_write_position(CommunicationProtocol& communication_protocol) {
 
 void write_position(CommunicationProtocol& communication_protocol) {
   const auto id = std::stoi(get_input("Enter servo ID: "));
-  communication_protocol.set_mode(id, OperationMode::kPosition).or_else([](const std::string& error) {
+  (void)communication_protocol.set_mode(id, OperationMode::kPosition).or_else([](const std::string& error) {
     throw std::runtime_error(error);
   });
   while (true) {
@@ -176,7 +176,7 @@ int main(int argc, char** argv) {
   const std::string port_name = argv[2];
 
   auto serial_port = std::make_unique<SerialPort>(port_name);
-  serial_port->configure().and_then([&] { return serial_port->open(); }).or_else([](const std::string& error) {
+  (void)serial_port->configure().and_then([&] { return serial_port->open(); }).or_else([](const std::string& error) {
     throw std::runtime_error(error);
   });
 

--- a/feetech_driver/examples/demo.cpp
+++ b/feetech_driver/examples/demo.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <range/v3/all.hpp>
 #include <thread>
+#include <tuple>
 #include <unordered_map>
 
 using namespace std::chrono_literals;
@@ -21,24 +22,24 @@ static constexpr auto kSleepTime = 100ms;
 
 void print_models(CommunicationProtocol& communication_protocol) {
   for (std::size_t id = 0; id <= kMaxServoId; id++) {
-    (void)communication_protocol.read_model_number(id)
-        .and_then(get_model_name)
-        .and_then([=](const auto model_name) {
-          spdlog::info("Servo ID: {} - Model name: {}", id, model_name);
-          return Result{};
-        })
-        .or_else([=](const std::string& error) { spdlog::debug("Servo ID: {} - Error: {}", id, error); });
+    std::ignore = communication_protocol.read_model_number(id)
+                      .and_then(get_model_name)
+                      .and_then([=](const auto model_name) {
+                        spdlog::info("Servo ID: {} - Model name: {}", id, model_name);
+                        return Result{};
+                      })
+                      .or_else([=](const std::string& error) { spdlog::debug("Servo ID: {} - Error: {}", id, error); });
   }
 }
 
 void ping(CommunicationProtocol& communication_protocol) {
   const auto id = std::stoi(get_input("Enter servo ID: "));
-  (void)communication_protocol.ping(id)
-      .and_then([] {
-        spdlog::info("Ping success");
-        return Result{};
-      })
-      .or_else([](const std::string& error) { spdlog::error("Ping failed: [{}]", error); });
+  std::ignore = communication_protocol.ping(id)
+                    .and_then([] {
+                      spdlog::info("Ping success");
+                      return Result{};
+                    })
+                    .or_else([](const std::string& error) { spdlog::error("Ping failed: [{}]", error); });
 }
 
 void sync_read_position(CommunicationProtocol& communication_protocol) {
@@ -47,10 +48,10 @@ void sync_read_position(CommunicationProtocol& communication_protocol) {
   std::vector<std::array<uint8_t, 2>> positions(num_servos, {0, 0});
 
   while (true) {
-    (void)communication_protocol.sync_read(ids, SMS_STS_PRESENT_POSITION_L, &positions)
-        .or_else([&](const std::string& error) {
-          throw std::runtime_error(fmt::format("Failed to read position [ids={}]", ids, error));
-        });
+    std::ignore = communication_protocol.sync_read(ids, SMS_STS_PRESENT_POSITION_L, &positions)
+                      .or_else([&](const std::string& error) {
+                        throw std::runtime_error(fmt::format("Failed to read position [ids={}]", ids, error));
+                      });
     spdlog::info("Position: {}", positions | ranges::views::transform([](const auto& position) {
                                    return from_sts(WordBytes{.low = position[0], .high = position[1]});
                                  }) | ranges::views::transform(to_angle));
@@ -80,10 +81,10 @@ void sync_write_position(CommunicationProtocol& communication_protocol) {
     std::vector<int> positions(num_servos, from_angle(desired_joint_position));
 
     spdlog::info("Setting positions to {}", positions);
-    (void)communication_protocol.sync_write_position(ids, positions, speeds, accelerations)
-        .or_else([=](const std::string& error) {
-          throw std::runtime_error(fmt::format("Failed to set position [ids={}]", ids, error));
-        });
+    std::ignore = communication_protocol.sync_write_position(ids, positions, speeds, accelerations)
+                      .or_else([=](const std::string& error) {
+                        throw std::runtime_error(fmt::format("Failed to set position [ids={}]", ids, error));
+                      });
   }
 }
 
@@ -95,12 +96,13 @@ void reg_write_position(CommunicationProtocol& communication_protocol) {
 
     spdlog::info("Setting position to {}°: {}", desired_joint_position, data);
     for (uint8_t servo_id = 1; servo_id <= num_servos; servo_id++) {
-      (void)communication_protocol.reg_write_position(servo_id, data, 0, 0).or_else([=](const std::string& error) {
-        throw std::runtime_error(fmt::format("Failed to set position [id={}][{}]", servo_id, error));
-      });
+      std::ignore =
+          communication_protocol.reg_write_position(servo_id, data, 0, 0).or_else([=](const std::string& error) {
+            throw std::runtime_error(fmt::format("Failed to set position [id={}][{}]", servo_id, error));
+          });
     }
     get_input("Press enter to continue");
-    (void)communication_protocol.reg_write_action().or_else([](const std::string& error) {
+    std::ignore = communication_protocol.reg_write_action().or_else([](const std::string& error) {
       throw std::runtime_error(fmt::format("Failed to set position action [{}]", error));
     });
   }
@@ -108,7 +110,7 @@ void reg_write_position(CommunicationProtocol& communication_protocol) {
 
 void write_position(CommunicationProtocol& communication_protocol) {
   const auto id = std::stoi(get_input("Enter servo ID: "));
-  (void)communication_protocol.set_mode(id, OperationMode::kPosition).or_else([](const std::string& error) {
+  std::ignore = communication_protocol.set_mode(id, OperationMode::kPosition).or_else([](const std::string& error) {
     throw std::runtime_error(error);
   });
   while (true) {
@@ -176,9 +178,10 @@ int main(int argc, char** argv) {
   const std::string port_name = argv[2];
 
   auto serial_port = std::make_unique<SerialPort>(port_name);
-  (void)serial_port->configure().and_then([&] { return serial_port->open(); }).or_else([](const std::string& error) {
-    throw std::runtime_error(error);
-  });
+  std::ignore =
+      serial_port->configure().and_then([&] { return serial_port->open(); }).or_else([](const std::string& error) {
+        throw std::runtime_error(error);
+      });
 
   auto communication_protocol = CommunicationProtocol(std::move(serial_port));
   example->second(communication_protocol);

--- a/src/feetech_ros2_driver.cpp
+++ b/src/feetech_ros2_driver.cpp
@@ -11,6 +11,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <string>
 #include <string_view>
+#include <tuple>
 #include <vector>
 
 namespace feetech_ros2_driver {
@@ -68,7 +69,7 @@ CallbackReturn FeetechHardwareInterface::on_init(const hardware_interface::Hardw
     }
     // Disable holding torque for joints that do not have command interfaces.
     if (info_.joints[i].command_interfaces.empty()) {
-      (void)communication_protocol_->set_torque(joint_ids_[i], false);
+      std::ignore = communication_protocol_->set_torque(joint_ids_[i], false);
     }
   }
 

--- a/src/feetech_ros2_driver.cpp
+++ b/src/feetech_ros2_driver.cpp
@@ -68,7 +68,7 @@ CallbackReturn FeetechHardwareInterface::on_init(const hardware_interface::Hardw
     }
     // Disable holding torque for joints that do not have command interfaces.
     if (info_.joints[i].command_interfaces.empty()) {
-      communication_protocol_->set_torque(joint_ids_[i], false);
+      (void)communication_protocol_->set_torque(joint_ids_[i], false);
     }
   }
 


### PR DESCRIPTION
This PR fixes nodiscard errors coming at compilation time by explicitly discarding them.

This package is currently creating a regresion on `jazzy`:

https://repo.ros2.org/status_page/ros_jazzy_default.html?q=REGRESSION

Suggesting a quick fix to the compilation errors we are seeing in:

https://build.ros2.org/view/Jbin_uN64/job/Jbin_uN64__feetech_ros2_driver__ubuntu_noble_amd64__binary/125/console

I am looking to do a sync next week and if this is not fixed I will  have to downgrade the package. I would appreciate if you can **consider the fix and re-release the package with the fix** asap.

Thanks!